### PR TITLE
:bug: fix(Validations): Fix typo and add new option in 'PENNCNB_INVALID'

### DIFF
--- a/flourish_child/choices.py
+++ b/flourish_child/choices.py
@@ -554,6 +554,7 @@ OVERALL_MARKS = (
 )
 
 PENNCNB_INVALID = (
+    ('no_impact', 'No Impact'),
     ('child_ill', 'Child was ill'),
     ('sensory_handicap', 'Child has a sensory handicap'),
     ('motor_handicap', 'Child has a motor handicap'),

--- a/flourish_child/models/child_penn_cnb.py
+++ b/flourish_child/models/child_penn_cnb.py
@@ -53,8 +53,7 @@ class ChildPennCNB(ChildCrfModelMixin):
         verbose_name='Did any of the following impact the testing session',
         choices=PENNCNB_INVALID,
         max_length=30,
-        default='no_impact',
-        blank=True)
+        default='no_impact')
 
     impact_other = OtherCharField()
 


### PR DESCRIPTION
Corrected a typo in `brief_2_forms_validators.py`, changing the `other_specify_field` value from 'other_brief2_self_invalid_reason' to 'other_breif2_self_invalid_reason'. Also, added a new tuple ('no_impact', 'No Impact') in the 'PENNCNB_INVALID' list in `choices.py`. These changes were made to ensure accurate field names and cover all options for invalid reasons in the 'PENNCNB_INVALID' list.