### PR TITLE
:sparkles: feature (Anc Second Screening): Implemented multi-child su…

### DIFF
--- a/flourish_child/forms/birth_data_form.py
+++ b/flourish_child/forms/birth_data_form.py
@@ -16,6 +16,7 @@ class BirthDataForm(ChildModelFormMixin):
 
     def __init__(self, *args, **kwargs):
         super(BirthDataForm, self).__init__(*args, **kwargs)
+        self.subject_identifier = self.initial.get('subject_identifier')
         if self.antenatal_enrolment_obj:
             self.initial['gestational_age'] = self.antenatal_enrolment_obj.real_time_ga
         elif self.get_ga_confirmed:
@@ -40,7 +41,9 @@ class BirthDataForm(ChildModelFormMixin):
     def get_latest_ultrasound(self):
         try:
             return self.ultrasound_model_cls.objects.filter(
-                maternal_visit__appointment__subject_identifier=self.caregiver_subject_identifier).order_by(
+                child_subject_identifier=self.subject_identifier,
+                maternal_visit__appointment__subject_identifier=(
+                    self.caregiver_subject_identifier)).order_by(
                 '-report_datetime').first()
         except self.ultrasound_model_cls.DoesNotExist:
             return None
@@ -49,6 +52,7 @@ class BirthDataForm(ChildModelFormMixin):
     def antenatal_enrolment_obj(self):
         try:
             antenatal_enrolment_obj = self.antenatal_enrolment_cls.objects.get(
+                child_subject_identifier=self.subject_identifier,
                 subject_identifier=self.caregiver_subject_identifier)
         except self.antenatal_enrolment_cls.DoesNotExist:
             return None

--- a/flourish_child/helper_classes/child_fu_onschedule_helper.py
+++ b/flourish_child/helper_classes/child_fu_onschedule_helper.py
@@ -97,8 +97,6 @@ class ChildFollowUpEnrolmentHelper(object):
             subject_identifier=subject_identifier,
             schedule_name=schedule_name)
 
-        print("Going well..")
-
     def activate_child_fu_schedule(self):
 
         latest_child_appt = self.get_latest_completed_child_appointment(
@@ -110,8 +108,6 @@ class ChildFollowUpEnrolmentHelper(object):
 
             self.put_on_child_fu_schedule(latest_child_appt.schedule_name,
                                           latest_child_appt.subject_identifier)
-
-            print("Done!")
 
             if self.update_mother:
 

--- a/flourish_child/models/signals.py
+++ b/flourish_child/models/signals.py
@@ -319,7 +319,8 @@ def child_birth_on_post_save(sender, instance, raw, created, **kwargs):
         base_appt_datetime = None
         try:
             maternal_delivery_obj = maternal_delivery_cls.objects.get(
-                subject_identifier=caregiver_subject_identifier)
+                subject_identifier=caregiver_subject_identifier,
+                child_subject_identifier=instance.subject_identifier)
         except maternal_delivery_cls.DoesNotExist:
             pass
         else:

--- a/flourish_child/tests/subject_helper_class.py
+++ b/flourish_child/tests/subject_helper_class.py
@@ -59,12 +59,13 @@ class SubjectHelperClass:
             'flourish_caregiver.subjectconsent',
             **self.options)
 
-        mommy.make_recipe(
+        child_consent=mommy.make_recipe(
                 'flourish_caregiver.caregiverchildconsent',
                 subject_consent=subject_consent, )
 
         mommy.make_recipe(
             'flourish_caregiver.antenatalenrollment',
+            child_subject_identifier=child_consent.subject_identifier,
             subject_identifier=subject_consent.subject_identifier,)
 
         mommy.make_recipe(

--- a/flourish_child/tests/test_antenatal_enrolment_schedules.py
+++ b/flourish_child/tests/test_antenatal_enrolment_schedules.py
@@ -45,12 +45,14 @@ class TestAntenatalEnrolmentSchedules(TestCase):
 
         mommy.make_recipe(
             'flourish_caregiver.antenatalenrollment',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj.subject_identifier,
             current_hiv_status=NEG,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
             subject_identifier=self.preg_subject_consent.subject_identifier,
+            child_subject_identifier=self.preg_caregiver_child_consent_obj.subject_identifier,
             delivery_datetime=get_utcnow(),
             live_infants_to_register=1)
 

--- a/flourish_child/tests/test_automatic_fu_booking.py
+++ b/flourish_child/tests/test_automatic_fu_booking.py
@@ -136,11 +136,13 @@ class TestFuBooking(TestCase):
         mommy.make_recipe(
             'flourish_caregiver.antenatalenrollment',
             current_hiv_status=NEG,
+            child_subject_identifier=preg_caregiver_child_consent_obj.subject_identifier,
             subject_identifier=preg_subject_consent.subject_identifier,)
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
             subject_identifier=preg_subject_consent.subject_identifier,
+            child_subject_identifier=preg_caregiver_child_consent_obj.subject_identifier,
             delivery_datetime=get_utcnow(),
             live_infants_to_register=1)
 

--- a/flourish_child/tests/test_birth_requisitions.py
+++ b/flourish_child/tests/test_birth_requisitions.py
@@ -50,10 +50,12 @@ class TestBirthRequisitions(TestCase):
         mommy.make_recipe(
             'flourish_caregiver.antenatalenrollment',
             current_hiv_status=NEG,
+            child_subject_identifier=preg_caregiver_child_consent_obj.subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
             subject_identifier=self.preg_subject_consent.subject_identifier,
+            child_subject_identifier=preg_caregiver_child_consent_obj.subject_identifier,
             delivery_datetime=get_utcnow(),
             live_infants_to_register=1)
 
@@ -116,10 +118,12 @@ class TestBirthRequisitions(TestCase):
         mommy.make_recipe(
             'flourish_caregiver.antenatalenrollment',
             current_hiv_status=NEG,
+            child_subject_identifier=preg_caregiver_child_consent_obj.subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
             subject_identifier=self.preg_subject_consent.subject_identifier,
+            child_subject_identifier=preg_caregiver_child_consent_obj.subject_identifier,
             delivery_datetime=get_utcnow(),
             live_infants_to_register=1)
 

--- a/flourish_child/tests/test_child_rule_groups_cohort_a.py
+++ b/flourish_child/tests/test_child_rule_groups_cohort_a.py
@@ -1,4 +1,5 @@
 from django.utils.datetime_safe import datetime
+from flourish_caregiver.models import CaregiverChildConsent
 
 from dateutil.relativedelta import relativedelta
 from django.test import TestCase, tag
@@ -54,12 +55,16 @@ class TestRuleGroups(TestCase):
         mommy.make_recipe(
             'flourish_caregiver.antenatalenrollment',
             current_hiv_status=NEG,
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
             subject_identifier=self.preg_subject_consent.subject_identifier,
             delivery_datetime=get_utcnow(),
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             live_infants_to_register=1)
 
         mommy.make_recipe(
@@ -95,12 +100,16 @@ class TestRuleGroups(TestCase):
         mommy.make_recipe(
             'flourish_caregiver.antenatalenrollment',
             current_hiv_status=NEG,
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
             subject_identifier=self.preg_subject_consent.subject_identifier,
             delivery_datetime=get_utcnow(),
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             live_infants_to_register=1)
 
         mommy.make_recipe(
@@ -136,12 +145,16 @@ class TestRuleGroups(TestCase):
         mommy.make_recipe(
             'flourish_caregiver.antenatalenrollment',
             current_hiv_status=NEG,
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
             subject_identifier=self.preg_subject_consent.subject_identifier,
             delivery_datetime=get_utcnow(),
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             live_infants_to_register=1)
 
         mommy.make_recipe(
@@ -195,11 +208,15 @@ class TestRuleGroups(TestCase):
         mommy.make_recipe(
             'flourish_caregiver.antenatalenrollment',
             current_hiv_status=NEG,
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
             subject_identifier=self.preg_subject_consent.subject_identifier,
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             live_infants_to_register=1)
 
         mommy.make_recipe(
@@ -237,10 +254,14 @@ class TestRuleGroups(TestCase):
         mommy.make_recipe(
             'flourish_caregiver.antenatalenrollment',
             current_hiv_status=POS,
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
@@ -267,10 +288,14 @@ class TestRuleGroups(TestCase):
         mommy.make_recipe(
             'flourish_caregiver.antenatalenrollment',
             current_hiv_status=NEG,
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
@@ -297,10 +322,14 @@ class TestRuleGroups(TestCase):
         mommy.make_recipe(
             'flourish_caregiver.antenatalenrollment',
             current_hiv_status=NEG,
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
@@ -328,10 +357,14 @@ class TestRuleGroups(TestCase):
         mommy.make_recipe(
             'flourish_caregiver.antenatalenrollment',
             current_hiv_status=POS,
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
@@ -365,10 +398,14 @@ class TestRuleGroups(TestCase):
         mommy.make_recipe(
             'flourish_caregiver.antenatalenrollment',
             current_hiv_status=POS,
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
@@ -431,11 +468,15 @@ class TestRuleGroups(TestCase):
     def test_infant_hiv_test_infant_feeding_hiv_test(self):
         mommy.make_recipe(
             'flourish_caregiver.antenatalenrollment',
-            current_hiv_status=POS,
+            current_hiv_status=NEG,
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
@@ -498,10 +539,14 @@ class TestRuleGroups(TestCase):
         mommy.make_recipe(
             'flourish_caregiver.antenatalenrollment',
             current_hiv_status=NEG,
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
@@ -564,10 +609,14 @@ class TestRuleGroups(TestCase):
         mommy.make_recipe(
             'flourish_caregiver.antenatalenrollment',
             current_hiv_status=NEG,
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
@@ -616,10 +665,14 @@ class TestRuleGroups(TestCase):
         mommy.make_recipe(
             'flourish_caregiver.antenatalenrollment',
             current_hiv_status=POS,
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
@@ -669,10 +722,14 @@ class TestRuleGroups(TestCase):
         mommy.make_recipe(
             'flourish_caregiver.antenatalenrollment',
             current_hiv_status=POS,
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
@@ -693,7 +750,7 @@ class TestRuleGroups(TestCase):
                 model='flourish_child.infantarvprophylaxis',
                 subject_identifier=self.preg_caregiver_child_consent_obj.subject_identifier,
                 visit_code='2000D', ).exists(), False)
-        
+
     def test_arv_proph_2001_preg_pos_required(self):
         """ Assert ARV proph crf is required at 2001 if participant is
             ANC enrolled and POS.
@@ -701,10 +758,14 @@ class TestRuleGroups(TestCase):
         mommy.make_recipe(
             'flourish_caregiver.antenatalenrollment',
             current_hiv_status=POS,
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
@@ -733,17 +794,21 @@ class TestRuleGroups(TestCase):
                 model='flourish_child.infantarvprophylaxis',
                 subject_identifier=self.preg_caregiver_child_consent_obj.subject_identifier,
                 visit_code='2001', ).entry_status, REQUIRED)
-        
+
     def test_arv_proph_if_missed_at_2001(self):
         """ Assert ARV proph crf is required at next visit if missed at 2001
         """
         mommy.make_recipe(
             'flourish_caregiver.antenatalenrollment',
             current_hiv_status=POS,
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
@@ -788,10 +853,14 @@ class TestRuleGroups(TestCase):
         mommy.make_recipe(
             'flourish_caregiver.antenatalenrollment',
             current_hiv_status=POS,
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
@@ -841,10 +910,14 @@ class TestRuleGroups(TestCase):
         mommy.make_recipe(
             'flourish_caregiver.antenatalenrollment',
             current_hiv_status=POS,
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
@@ -894,10 +967,14 @@ class TestRuleGroups(TestCase):
         mommy.make_recipe(
             'flourish_caregiver.antenatalenrollment',
             current_hiv_status=POS,
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(

--- a/flourish_child/tests/test_child_rule_groups_cohort_c.py
+++ b/flourish_child/tests/test_child_rule_groups_cohort_c.py
@@ -183,10 +183,12 @@ class TestRuleGroups(TestCase):
 
         mommy.make_recipe(
             'flourish_caregiver.antenatalenrollment',
+            child_subject_identifier=caregiver_child_consent_obj.subject_identifier,
             subject_identifier=subject_consent.subject_identifier,)
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
+            child_subject_identifier=caregiver_child_consent_obj.subject_identifier,
             subject_identifier=subject_consent.subject_identifier,)
 
         mommy.make_recipe(
@@ -236,10 +238,12 @@ class TestRuleGroups(TestCase):
 
         mommy.make_recipe(
             'flourish_caregiver.antenatalenrollment',
+            child_subject_identifier=caregiver_child_consent_obj.subject_identifier,
             subject_identifier=subject_consent.subject_identifier,)
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
+            child_subject_identifier=caregiver_child_consent_obj.subject_identifier,
             subject_identifier=subject_consent.subject_identifier,)
 
         mommy.make_recipe(

--- a/flourish_child/tests/test_hiv_infant_testing.py
+++ b/flourish_child/tests/test_hiv_infant_testing.py
@@ -77,11 +77,15 @@ class TestHivInfantTesting(TestCase):
         mommy.make_recipe(
             'flourish_caregiver.antenatalenrollment',
             current_hiv_status=POS,
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
             subject_identifier=self.preg_subject_consent.subject_identifier,
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             delivery_datetime=get_utcnow() - relativedelta(years=1, months=3),
             live_infants_to_register=1)
 

--- a/flourish_child/tests/test_missed_birth_visit.py
+++ b/flourish_child/tests/test_missed_birth_visit.py
@@ -48,10 +48,14 @@ class TestMissedBirthVisit(TestCase):
         mommy.make_recipe(
             'flourish_caregiver.antenatalenrollment',
             current_hiv_status=NEG,
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier,
             delivery_datetime=get_utcnow(),
             live_infants_to_register=1)
@@ -90,10 +94,14 @@ class TestMissedBirthVisit(TestCase):
         mommy.make_recipe(
             'flourish_caregiver.antenatalenrollment',
             current_hiv_status=NEG,
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier,
             delivery_datetime=get_utcnow(),
             live_infants_to_register=1)

--- a/flourish_child/tests/test_visit_schedule_setup.py
+++ b/flourish_child/tests/test_visit_schedule_setup.py
@@ -73,10 +73,12 @@ class TestVisitScheduleSetup(TestCase):
 
         mommy.make_recipe(
             'flourish_caregiver.antenatalenrollment',
+            child_subject_identifier=child_consent.subject_identifier,
             subject_identifier=subject_consent.subject_identifier,)
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
+            child_subject_identifier=child_consent.subject_identifier,
             subject_identifier=subject_consent.subject_identifier,
             delivery_datetime=get_utcnow(),
             live_infants_to_register=1)


### PR DESCRIPTION
…pport for ANC enrolledCaregiver

This commit addresses various changes to support the inclusion of multiple children to one caregiver in the Flourish Caregiver project. Child subject identifiers were added to antenatal screenings, ultra sounds, maternal deliveries and enrollment forms. The dashboard was updated to reflect the multi-child support. The addition of child subject identifiers aids in improving the tracking process, especially when handling multi-child scenarios. Lastly, print statements were removed for a cleaner codebase.