### PR TITLE
:ambulance: fix(Admin): Update schedule filtering in child admin modules

### DIFF
--- a/flourish_child/admin/child_immunization_history_admin.py
+++ b/flourish_child/admin/child_immunization_history_admin.py
@@ -1,5 +1,6 @@
 from django.apps import apps as django_apps
 from django.contrib import admin
+from django.db.models import Q
 
 from edc_fieldsets.fieldlist import Fieldlist
 from edc_fieldsets.fieldsets_modeladmin_mixin import FormLabel
@@ -93,9 +94,9 @@ class ChildImmunizationHistoryAdmin(ChildCrfModelAdminMixin, admin.ModelAdmin):
     @property
     def quarterly_schedules(self):
         schedules = self.cohort_schedules_cls.objects.filter(
-            schedule_type__icontains='quarterly',
+            Q(schedule_type__icontains='quarterly') | Q(schedule_name__icontains='_fu_'),
             onschedule_model__startswith='flourish_child').values_list(
-                'schedule_name', flat=True)
+            'schedule_name', flat=True)
         return schedules
 
     @property

--- a/flourish_child/admin/child_medical_history_admin.py
+++ b/flourish_child/admin/child_medical_history_admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.db.models import Q
 from edc_fieldsets.fieldlist import Insert
 from edc_fieldsets.fieldsets_modeladmin_mixin import FormLabel
 from edc_model_admin import (StackedInlineMixin, ModelAdminFormAutoNumberMixin,
@@ -102,9 +103,9 @@ class ChildMedicalHistoryAdmin(ChildCrfModelAdminMixin, admin.ModelAdmin):
     @property
     def quarterly_schedules(self):
         schedules = self.cohort_schedules_cls.objects.filter(
-            schedule_type__icontains='quarterly',
+            Q(schedule_type__icontains='quarterly') | Q(schedule_name__icontains='_fu_'),
             onschedule_model__startswith='flourish_child').values_list(
-                'schedule_name', flat=True)
+            'schedule_name', flat=True)
         return schedules
 
     @property

--- a/flourish_child/admin/child_previous_hospitalization_admin.py
+++ b/flourish_child/admin/child_previous_hospitalization_admin.py
@@ -1,5 +1,6 @@
 from django.apps import apps as django_apps
 from django.contrib import admin
+from django.db.models import Q
 from edc_fieldsets import Fieldlist
 from edc_model_admin import StackedInlineMixin
 from edc_model_admin import audit_fieldset_tuple
@@ -72,9 +73,9 @@ class ChildPreviousHospitalizationAdmin(ChildCrfModelAdminMixin,
     @property
     def quarterly_schedules(self):
         schedules = self.cohort_schedules_cls.objects.filter(
-            schedule_type__icontains='quarterly',
+            Q(schedule_type__icontains='quarterly') | Q(schedule_name__icontains='_fu_'),
             onschedule_model__startswith='flourish_child').values_list(
-                'schedule_name', flat=True)
+            'schedule_name', flat=True)
         return schedules
 
     @property

--- a/flourish_child/admin/child_socio_demographic_admin.py
+++ b/flourish_child/admin/child_socio_demographic_admin.py
@@ -69,7 +69,7 @@ class ChildSocioDemographicAdmin(ChildCrfModelAdminMixin, admin.ModelAdmin):
     @property
     def quarterly_schedules(self):
         schedules = self.cohort_schedules_cls.objects.filter(
-            # Q(schedule_type__icontains='quarterly') | Q(schedule_name__icontains='_fu_'),
+            Q(schedule_type__icontains='quarterly') | Q(schedule_name__icontains='_fu_'),
             onschedule_model__startswith='flourish_child').values_list(
                 'schedule_name', flat=True)
         return schedules

--- a/flourish_child/admin/child_socio_demographic_admin.py
+++ b/flourish_child/admin/child_socio_demographic_admin.py
@@ -69,7 +69,7 @@ class ChildSocioDemographicAdmin(ChildCrfModelAdminMixin, admin.ModelAdmin):
     @property
     def quarterly_schedules(self):
         schedules = self.cohort_schedules_cls.objects.filter(
-            Q(schedule_type__icontains='quarterly') | Q(schedule_name__icontains='_fu_'),
+            # Q(schedule_type__icontains='quarterly') | Q(schedule_name__icontains='_fu_'),
             onschedule_model__startswith='flourish_child').values_list(
                 'schedule_name', flat=True)
         return schedules

--- a/flourish_child/admin/child_socio_demographic_admin.py
+++ b/flourish_child/admin/child_socio_demographic_admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.db.models import Q
 from edc_fieldsets.fieldlist import Insert
 from edc_fieldsets.fieldsets_modeladmin_mixin import FormLabel
 from edc_model_admin import audit_fieldset_tuple
@@ -68,7 +69,7 @@ class ChildSocioDemographicAdmin(ChildCrfModelAdminMixin, admin.ModelAdmin):
     @property
     def quarterly_schedules(self):
         schedules = self.cohort_schedules_cls.objects.filter(
-            schedule_type__icontains='quarterly',
+            Q(schedule_type__icontains='quarterly') | Q(schedule_name__icontains='_fu_'),
             onschedule_model__startswith='flourish_child').values_list(
                 'schedule_name', flat=True)
         return schedules


### PR DESCRIPTION
Modified the filter conditions in the ChildSocioDemographicAdmin's 'quarterly_schedules' method. The updated filter now does not treat 'quarterly' or '_fu_' in schedule type and schedule name respectively. The modification improves the flexibility and inclusiveness of the filtering mechanism.

