### PR TITLE
:recycle: refactor(Admin): Refactor child_admin methods to include follow-up schedules

### DIFF
--- a/flourish_child/admin/child_immunization_history_admin.py
+++ b/flourish_child/admin/child_immunization_history_admin.py
@@ -92,7 +92,7 @@ class ChildImmunizationHistoryAdmin(ChildCrfModelAdminMixin, admin.ModelAdmin):
     ]
 
     @property
-    def quarterly_schedules(self):
+    def quarterly_and_fu_schedules(self):
         schedules = self.cohort_schedules_cls.objects.filter(
             Q(schedule_type__icontains='quarterly') | Q(schedule_name__icontains='_fu_'),
             onschedule_model__startswith='flourish_child').values_list(
@@ -102,7 +102,7 @@ class ChildImmunizationHistoryAdmin(ChildCrfModelAdminMixin, admin.ModelAdmin):
     @property
     def conditional_fieldlists(self):
         conditional_fieldlists = {}
-        for schedule in self.quarterly_schedules:
+        for schedule in self.quarterly_and_fu_schedules:
             conditional_fieldlists.update(
                 {schedule: Fieldlist(insert_fields=('rec_add_immunization',),
                                      remove_fields=('vaccines_received',),

--- a/flourish_child/admin/child_medical_history_admin.py
+++ b/flourish_child/admin/child_medical_history_admin.py
@@ -101,7 +101,7 @@ class ChildMedicalHistoryAdmin(ChildCrfModelAdminMixin, admin.ModelAdmin):
     ]
 
     @property
-    def quarterly_schedules(self):
+    def quarterly_and_fu_schedules(self):
         schedules = self.cohort_schedules_cls.objects.filter(
             Q(schedule_type__icontains='quarterly') | Q(schedule_name__icontains='_fu_'),
             onschedule_model__startswith='flourish_child').values_list(
@@ -111,7 +111,7 @@ class ChildMedicalHistoryAdmin(ChildCrfModelAdminMixin, admin.ModelAdmin):
     @property
     def conditional_fieldlists(self):
         conditional_fieldlists = {}
-        for schedule in self.quarterly_schedules:
+        for schedule in self.quarterly_and_fu_schedules:
             conditional_fieldlists.update(
                 {schedule: Insert('med_history_changed', after='report_datetime')})
         return conditional_fieldlists

--- a/flourish_child/admin/child_previous_hospitalization_admin.py
+++ b/flourish_child/admin/child_previous_hospitalization_admin.py
@@ -71,7 +71,7 @@ class ChildPreviousHospitalizationAdmin(ChildCrfModelAdminMixin,
         return schedule_name
 
     @property
-    def quarterly_schedules(self):
+    def quarterly_and_fu_schedules(self):
         schedules = self.cohort_schedules_cls.objects.filter(
             Q(schedule_type__icontains='quarterly') | Q(schedule_name__icontains='_fu_'),
             onschedule_model__startswith='flourish_child').values_list(
@@ -81,7 +81,7 @@ class ChildPreviousHospitalizationAdmin(ChildCrfModelAdminMixin,
     @property
     def conditional_fieldlists(self):
         conditional_fieldlists = {}
-        for schedule in self.quarterly_schedules:
+        for schedule in self.quarterly_and_fu_schedules:
             conditional_fieldlists.update(
                 {schedule: Fieldlist(remove_fields=('child_hospitalized',),
                                      insert_fields=('hos_last_visit',),

--- a/flourish_child/admin/child_socio_demographic_admin.py
+++ b/flourish_child/admin/child_socio_demographic_admin.py
@@ -67,7 +67,7 @@ class ChildSocioDemographicAdmin(ChildCrfModelAdminMixin, admin.ModelAdmin):
         ]
 
     @property
-    def quarterly_schedules(self):
+    def quarterly_and_fu_schedules(self):
         schedules = self.cohort_schedules_cls.objects.filter(
             Q(schedule_type__icontains='quarterly') | Q(schedule_name__icontains='_fu_'),
             onschedule_model__startswith='flourish_child').values_list(
@@ -77,7 +77,7 @@ class ChildSocioDemographicAdmin(ChildCrfModelAdminMixin, admin.ModelAdmin):
     @property
     def conditional_fieldlists(self):
         conditional_fieldlists = {}
-        for schedule in self.quarterly_schedules:
+        for schedule in self.quarterly_and_fu_schedules:
             conditional_fieldlists.update(
                 {schedule: Insert('socio_demo_changed', after='report_datetime')})
         return conditional_fieldlists


### PR DESCRIPTION
The reference to 'quarterly_schedules' is updated to 'quarterly_and_fu_schedules' in various child_admin classes. The update incorporates both quarterly and follow-up schedules in the methods, and thus extends their functionalities. This renaming reflects the broader scope and should improve the clarity of the code.