### PR TITLE
:ambulance: refactor(Admin): Update schedule filtering in child admin modules

### DIFF
--- a/flourish_child/admin/child_immunization_history_admin.py
+++ b/flourish_child/admin/child_immunization_history_admin.py
@@ -1,5 +1,6 @@
 from django.apps import apps as django_apps
 from django.contrib import admin
+from django.db.models import Q
 
 from edc_fieldsets.fieldlist import Fieldlist
 from edc_fieldsets.fieldsets_modeladmin_mixin import FormLabel
@@ -91,17 +92,17 @@ class ChildImmunizationHistoryAdmin(ChildCrfModelAdminMixin, admin.ModelAdmin):
     ]
 
     @property
-    def quarterly_schedules(self):
+    def quarterly_and_fu_schedules(self):
         schedules = self.cohort_schedules_cls.objects.filter(
-            schedule_type__icontains='quarterly',
+            Q(schedule_type__icontains='quarterly') | Q(schedule_name__icontains='_fu_'),
             onschedule_model__startswith='flourish_child').values_list(
-                'schedule_name', flat=True)
+            'schedule_name', flat=True)
         return schedules
 
     @property
     def conditional_fieldlists(self):
         conditional_fieldlists = {}
-        for schedule in self.quarterly_schedules:
+        for schedule in self.quarterly_and_fu_schedules:
             conditional_fieldlists.update(
                 {schedule: Fieldlist(insert_fields=('rec_add_immunization',),
                                      remove_fields=('vaccines_received',),

--- a/flourish_child/admin/child_medical_history_admin.py
+++ b/flourish_child/admin/child_medical_history_admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.db.models import Q
 from edc_fieldsets.fieldlist import Insert
 from edc_fieldsets.fieldsets_modeladmin_mixin import FormLabel
 from edc_model_admin import (StackedInlineMixin, ModelAdminFormAutoNumberMixin,
@@ -100,17 +101,17 @@ class ChildMedicalHistoryAdmin(ChildCrfModelAdminMixin, admin.ModelAdmin):
     ]
 
     @property
-    def quarterly_schedules(self):
+    def quarterly_and_fu_schedules(self):
         schedules = self.cohort_schedules_cls.objects.filter(
-            schedule_type__icontains='quarterly',
+            Q(schedule_type__icontains='quarterly') | Q(schedule_name__icontains='_fu_'),
             onschedule_model__startswith='flourish_child').values_list(
-                'schedule_name', flat=True)
+            'schedule_name', flat=True)
         return schedules
 
     @property
     def conditional_fieldlists(self):
         conditional_fieldlists = {}
-        for schedule in self.quarterly_schedules:
+        for schedule in self.quarterly_and_fu_schedules:
             conditional_fieldlists.update(
                 {schedule: Insert('med_history_changed', after='report_datetime')})
         return conditional_fieldlists

--- a/flourish_child/admin/child_previous_hospitalization_admin.py
+++ b/flourish_child/admin/child_previous_hospitalization_admin.py
@@ -1,5 +1,6 @@
 from django.apps import apps as django_apps
 from django.contrib import admin
+from django.db.models import Q
 from edc_fieldsets import Fieldlist
 from edc_model_admin import StackedInlineMixin
 from edc_model_admin import audit_fieldset_tuple
@@ -70,17 +71,17 @@ class ChildPreviousHospitalizationAdmin(ChildCrfModelAdminMixin,
         return schedule_name
 
     @property
-    def quarterly_schedules(self):
+    def quarterly_and_fu_schedules(self):
         schedules = self.cohort_schedules_cls.objects.filter(
-            schedule_type__icontains='quarterly',
+            Q(schedule_type__icontains='quarterly') | Q(schedule_name__icontains='_fu_'),
             onschedule_model__startswith='flourish_child').values_list(
-                'schedule_name', flat=True)
+            'schedule_name', flat=True)
         return schedules
 
     @property
     def conditional_fieldlists(self):
         conditional_fieldlists = {}
-        for schedule in self.quarterly_schedules:
+        for schedule in self.quarterly_and_fu_schedules:
             conditional_fieldlists.update(
                 {schedule: Fieldlist(remove_fields=('child_hospitalized',),
                                      insert_fields=('hos_last_visit',),

--- a/flourish_child/admin/child_socio_demographic_admin.py
+++ b/flourish_child/admin/child_socio_demographic_admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.db.models import Q
 from edc_fieldsets.fieldlist import Insert
 from edc_fieldsets.fieldsets_modeladmin_mixin import FormLabel
 from edc_model_admin import audit_fieldset_tuple
@@ -66,9 +67,9 @@ class ChildSocioDemographicAdmin(ChildCrfModelAdminMixin, admin.ModelAdmin):
         ]
 
     @property
-    def quarterly_schedules(self):
+    def quarterly_and_fu_schedules(self):
         schedules = self.cohort_schedules_cls.objects.filter(
-            schedule_type__icontains='quarterly',
+            Q(schedule_type__icontains='quarterly') | Q(schedule_name__icontains='_fu_'),
             onschedule_model__startswith='flourish_child').values_list(
                 'schedule_name', flat=True)
         return schedules
@@ -76,7 +77,7 @@ class ChildSocioDemographicAdmin(ChildCrfModelAdminMixin, admin.ModelAdmin):
     @property
     def conditional_fieldlists(self):
         conditional_fieldlists = {}
-        for schedule in self.quarterly_schedules:
+        for schedule in self.quarterly_and_fu_schedules:
             conditional_fieldlists.update(
                 {schedule: Insert('socio_demo_changed', after='report_datetime')})
         return conditional_fieldlists


### PR DESCRIPTION
Updated the schedule filtering function in `child_medical_history`, `child_immunization_history`, `child_socio_demographic` and `child_previous_hospitalization` admin modules. Extended the filter to include schedules that contain 'quarterly' or '_fu_' in their type or name. This change will allow the system to capture not only the quarterly schedules but also the follow up schedules.