### PR TITLE
refactor(Admin): Remove 'tb_tests' field from admin display in Child model



### DIFF
--- a/flourish_child/admin/child_tb_screening_admin.py
+++ b/flourish_child/admin/child_tb_screening_admin.py
@@ -69,3 +69,5 @@ class ChildTBScreeningAdmin(ChildCrfModelAdminMixin, admin.ModelAdmin):
         "child_on_tb_preventive_therapy": admin.VERTICAL,
     }
 
+    filter_horizontal = ('tb_tests',)
+

--- a/flourish_child/admin/child_tb_screening_admin.py
+++ b/flourish_child/admin/child_tb_screening_admin.py
@@ -58,7 +58,6 @@ class ChildTBScreeningAdmin(ChildCrfModelAdminMixin, admin.ModelAdmin):
         "fatigue_or_reduced_playfulness": admin.VERTICAL,
         "household_diagnosed_with_tb": admin.VERTICAL,
         "evaluated_for_tb": admin.VERTICAL,
-        "tb_tests": admin.VERTICAL,
         "chest_xray_results": admin.VERTICAL,
         "sputum_sample_results": admin.VERTICAL,
         "stool_sample_results": admin.VERTICAL,


### PR DESCRIPTION
This commit removes the 'tb_tests' field from the admin display in Child model. This is part of a refactoring process where 'tb_tests' field has been updated and its representation in different parts of the system is being adjusted accordingly.