### PR TITLE
Add flourish_export app in settings.py


### DIFF
--- a/flourish_child/settings.py
+++ b/flourish_child/settings.py
@@ -72,6 +72,7 @@ INSTALLED_APPS = [
     'edc_visit_schedule.apps.AppConfig',
     'edc_model_admin.apps.AppConfig',
     'flourish_prn.apps.AppConfig',
+    'flourish_export.apps.AppConfig',
     'flourish_reference.apps.AppConfig',
     'flourish_metadata_rules.apps.AppConfig',
     'flourish_follow.apps.AppConfig',


### PR DESCRIPTION

'flourish_export.apps.AppConfig' has been added to the installed apps list in settings.py of the flourish-child project. This ensures that the functionality provided by the flourish_export app is available within the flourish-child application.