### PR TITLE
(Update): Adjust post-breastfeeding testing period to 6 weeks


### DIFF
--- a/flourish_child/list_data.py
+++ b/flourish_child/list_data.py
@@ -290,7 +290,7 @@ list_data = {
         ('6_to_8_weeks', '6 to 8 weeks'),
         ('9_months', '9-months'),
         ('18_months', '18-months'),
-        ('after_breastfeeding', 'Three months after cessation of breastfeeding'),
+        ('after_breastfeeding', '3 weeks after cessation of breastfeeding'),
         (OTHER, 'Other, specify')
     ],
     'flourish_child.childhivnottestedreason': [

--- a/flourish_child/models/infant_hiv_testing.py
+++ b/flourish_child/models/infant_hiv_testing.py
@@ -15,15 +15,15 @@ class InfantHIVTesting(ChildCrfModelMixin, HivTestingModelMixin):
 
 class InfantHIVTestingAfterBreastfeeding(ChildCrfModelMixin, HIVTestingAndResultingMixin):
     child_tested_for_hiv = models.DateField(
-        verbose_name='Date of the HIV test at 3 Months after Cessation of Breastfeeding',
+        verbose_name='Date of the HIV test at 6 weeks after Cessation of Breastfeeding',
     )
 
     class Meta(ChildCrfModelMixin.Meta):
         app_label = 'flourish_child'
-        verbose_name = ('HIV Infant Testing and Results, Three Months After Cessation of '
+        verbose_name = ('HIV Infant Testing and Results, 6 Weeks After Cessation of '
                         'Breastfeeding')
         verbose_name_plural = (
-            'HIV Infant Testing and Results, Three Months After Cessation of '
+            'HIV Infant Testing and Results, 6 Weeks After Cessation of '
             'Breastfeeding')
 
 


### PR DESCRIPTION

The timeframe for HIV testing post-breastfeeding cessation was adjusted within both model and static text. Initially, the testing time was set at three months after stopping breastfeeding. Now it has been updated to six weeks post-cessation, for consistency and accuracy. Signed-off-by: nmunatsibw 