### PR TITLE
(Update): Modify after breastfeeding period in list_data.py



### DIFF
--- a/flourish_child/list_data.py
+++ b/flourish_child/list_data.py
@@ -290,7 +290,7 @@ list_data = {
         ('6_to_8_weeks', '6 to 8 weeks'),
         ('9_months', '9-months'),
         ('18_months', '18-months'),
-        ('after_breastfeeding', '3 weeks after cessation of breastfeeding'),
+        ('after_breastfeeding', '6 weeks after cessation of breastfeeding'),
         (OTHER, 'Other, specify')
     ],
     'flourish_child.childhivnottestedreason': [


### PR DESCRIPTION
The time frame for the 'after_breastfeeding' tag in the list_data.py file has been adjusted. It was previously marked as '3 weeks after cessation of breastfeeding', it's now been updated to '6 weeks after cessation of breastfeeding'. Signed-off-by: nmunatsibw 