### PR TITLE
(refactor): Update new functionalities in Flourish Child App



### DIFF
--- a/flourish_child/apps.py
+++ b/flourish_child/apps.py
@@ -18,6 +18,7 @@ class AppConfig(DjangoAppConfig):
 
     def ready(self):
         from .models import child_consent_on_post_save
+        import flourish_child.models.signals
 
 
 if settings.APP_NAME == 'flourish_child':

--- a/flourish_child/apps.py
+++ b/flourish_child/apps.py
@@ -59,9 +59,11 @@ if settings.APP_NAME == 'flourish_child':
 
 
     class EdcMetadataAppConfig(BaseEdcMetadataAppConfig):
-        reason_field = {'flourish_child.childvisit': 'reason',
-                        'pre_flourish.preflourishvisit': 'reason',
-                        'flourish_facet.facetvisit': 'reason', }
+        reason_field = {
+            'pre_flourish.preflourishvisit': 'reason',
+            'flourish_caregiver.maternalvisit': 'reason',
+            'flourish_child.childvisit': 'reason',
+            'flourish_facet.facetvisit': 'reason', }
         create_on_reasons = [SCHEDULED, UNSCHEDULED, COMPLETED_PROTOCOL_VISIT]
         delete_on_reasons = [LOST_VISIT, MISSED_VISIT, FAILED_ELIGIBILITY]
 

--- a/flourish_child/forms/infant_hiv_testing_form.py
+++ b/flourish_child/forms/infant_hiv_testing_form.py
@@ -1,8 +1,8 @@
 from django import forms
 
-from flourish_caregiver.forms.form_mixins import SubjectModelFormMixin
 from flourish_child_validations.form_validators import \
     InfantHIVTestingAdminFormValidatorRepeat, InfantHIVTestingFormValidator
+from .child_form_mixin import ChildModelFormMixin
 from ..models import (InfantHIVTesting, InfantHIVTesting18Months,
                       InfantHIVTesting9Months,
                       InfantHIVTestingAfterBreastfeeding, InfantHIVTestingAge6To8Weeks,
@@ -10,7 +10,7 @@ from ..models import (InfantHIVTesting, InfantHIVTesting18Months,
                       InfantHIVTestingOther)
 
 
-class InfantHIVTestingForm(SubjectModelFormMixin, forms.ModelForm):
+class InfantHIVTestingForm(ChildModelFormMixin, forms.ModelForm):
     form_validator_cls = InfantHIVTestingFormValidator
 
     class Meta:
@@ -18,7 +18,7 @@ class InfantHIVTestingForm(SubjectModelFormMixin, forms.ModelForm):
         fields = '__all__'
 
 
-class InfantHIVTestingAfterBreastfeedingForm(SubjectModelFormMixin, forms.ModelForm):
+class InfantHIVTestingAfterBreastfeedingForm(ChildModelFormMixin, forms.ModelForm):
     form_validator_cls = InfantHIVTestingAdminFormValidatorRepeat
 
     class Meta:
@@ -26,7 +26,7 @@ class InfantHIVTestingAfterBreastfeedingForm(SubjectModelFormMixin, forms.ModelF
         fields = '__all__'
 
 
-class InfantHIVTestingAge6To8WeeksForm(SubjectModelFormMixin, forms.ModelForm):
+class InfantHIVTestingAge6To8WeeksForm(ChildModelFormMixin, forms.ModelForm):
     form_validator_cls = InfantHIVTestingAdminFormValidatorRepeat
 
     class Meta:
@@ -34,7 +34,7 @@ class InfantHIVTestingAge6To8WeeksForm(SubjectModelFormMixin, forms.ModelForm):
         fields = '__all__'
 
 
-class InfantHIVTesting9MonthsForm(SubjectModelFormMixin, forms.ModelForm):
+class InfantHIVTesting9MonthsForm(ChildModelFormMixin, forms.ModelForm):
     form_validator_cls = InfantHIVTestingAdminFormValidatorRepeat
 
     class Meta:
@@ -42,7 +42,7 @@ class InfantHIVTesting9MonthsForm(SubjectModelFormMixin, forms.ModelForm):
         fields = '__all__'
 
 
-class InfantHIVTesting18MonthsForm(SubjectModelFormMixin, forms.ModelForm):
+class InfantHIVTesting18MonthsForm(ChildModelFormMixin, forms.ModelForm):
     form_validator_cls = InfantHIVTestingAdminFormValidatorRepeat
 
     class Meta:
@@ -50,7 +50,7 @@ class InfantHIVTesting18MonthsForm(SubjectModelFormMixin, forms.ModelForm):
         fields = '__all__'
 
 
-class InfantHIVTestingBirthForm(SubjectModelFormMixin, forms.ModelForm):
+class InfantHIVTestingBirthForm(ChildModelFormMixin, forms.ModelForm):
     form_validator_cls = InfantHIVTestingAdminFormValidatorRepeat
 
     class Meta:
@@ -58,7 +58,7 @@ class InfantHIVTestingBirthForm(SubjectModelFormMixin, forms.ModelForm):
         fields = '__all__'
 
 
-class InfantHIVTestingOtherForm(SubjectModelFormMixin, forms.ModelForm):
+class InfantHIVTestingOtherForm(ChildModelFormMixin, forms.ModelForm):
     form_validator_cls = InfantHIVTestingAdminFormValidatorRepeat
 
     child_age = forms.DecimalField(

--- a/flourish_child/helper_classes/utils.py
+++ b/flourish_child/helper_classes/utils.py
@@ -209,6 +209,19 @@ def notification(subject_identifier, subject, user_created,
                     comment=comment)
 
 
+def handle_notification(visit, instance, subject):
+    try:
+        DataActionItem.objects.get(
+            subject_identifier=visit.subject_identifier,
+            subject=subject)
+    except DataActionItem.DoesNotExist:
+        notification(
+            subject_identifier=visit.subject_identifier,
+            user_created=instance.user_created,
+            subject=subject,
+            comment=f'{subject}. Please capture results once available.')
+
+
 def trigger_action_item(model_cls, action_name, subject_identifier, repeat=False):
     action_cls = site_action_items.get(
         model_cls.action_name)

--- a/flourish_child/models/model_mixins/hiv_testing_and_resulting_mixin.py
+++ b/flourish_child/models/model_mixins/hiv_testing_and_resulting_mixin.py
@@ -70,6 +70,10 @@ class HIVTestingAndResultingMixin(models.Model):
         super().save(*args, **kwargs)
         no_results = [IND, PENDING, UNKNOWN]
         if self.hiv_test_result in no_results:
+            if not self.child_visit:
+                raise RuntimeError("Error while creating the Unscheduled Appointment. "
+                                   "The visit seems invalid.")
+
             appointment_creator = UnscheduledAppointmentCreator(
                 subject_identifier=self.child_visit.subject_identifier,
                 visit_schedule_name=self.child_visit.appointment.visit_schedule_name,
@@ -79,6 +83,9 @@ class HIVTestingAndResultingMixin(models.Model):
                 timepoint_datetime=self.child_visit.appointment.timepoint_datetime,
             )
             obj = appointment_creator.appointment
+
+            if not obj:
+                RuntimeError("Unscheduled appointment not created")
             obj.save()
 
     class Meta:

--- a/flourish_child/models/model_mixins/hiv_testing_and_resulting_mixin.py
+++ b/flourish_child/models/model_mixins/hiv_testing_and_resulting_mixin.py
@@ -1,5 +1,6 @@
 from django.db import models
-from edc_appointment.creators import UnscheduledAppointmentCreator
+from edc_appointment.creators import UnscheduledAppointmentCreator, \
+    UnscheduledAppointmentError
 from edc_base.model_fields import OtherCharField
 from edc_constants.choices import YES_NO
 from edc_constants.constants import IND, PENDING, UNKNOWN
@@ -66,27 +67,6 @@ class HIVTestingAndResultingMixin(models.Model):
         blank=True,
     )
 
-    def save(self, *args, **kwargs):
-        super().save(*args, **kwargs)
-        no_results = [IND, PENDING, UNKNOWN]
-        if self.hiv_test_result in no_results:
-            if not self.child_visit:
-                raise RuntimeError("Error while creating the Unscheduled Appointment. "
-                                   "The visit seems invalid.")
-
-            appointment_creator = UnscheduledAppointmentCreator(
-                subject_identifier=self.child_visit.subject_identifier,
-                visit_schedule_name=self.child_visit.appointment.visit_schedule_name,
-                schedule_name=self.child_visit.appointment.schedule_name,
-                visit_code=self.child_visit.appointment.visit_code,
-                facility=self.child_visit.appointment.facility,
-                timepoint_datetime=self.child_visit.appointment.timepoint_datetime,
-            )
-            obj = appointment_creator.appointment
-
-            if not obj:
-                RuntimeError("Unscheduled appointment not created")
-            obj.save()
 
     class Meta:
         abstract = True

--- a/flourish_child/models/signals.py
+++ b/flourish_child/models/signals.py
@@ -3,16 +3,19 @@ from datetime import datetime
 import pytz
 from dateutil.relativedelta import relativedelta
 from django.apps import apps as django_apps
-from django.db.models.signals import post_save, m2m_changed
+from django.db.models.signals import m2m_changed, post_save
 from django.dispatch import receiver
 from django.forms import model_to_dict
 from edc_appointment.constants import COMPLETE_APPT
+from edc_appointment.creators import UnscheduledAppointmentCreator, \
+    UnscheduledAppointmentError
 from edc_base.utils import age, get_utcnow
-from edc_constants.constants import IND, MALE, NEG, NO, UNKNOWN, YES
+from edc_constants.constants import IND, MALE, NEG, NO, PENDING, UNKNOWN, YES
 from edc_data_manager.models import DataActionItem
 from edc_visit_schedule.site_visit_schedules import site_visit_schedules
-from edc_visit_tracking.constants import MISSED_VISIT
 from edc_visit_schedule.subject_schedule import InvalidOffscheduleDate
+from edc_visit_tracking.constants import MISSED_VISIT
+
 from flourish_child.models.adol_hiv_testing import HivTestingAdol
 from flourish_child.models.adol_tb_lab_results import TbLabResultsAdol
 from flourish_child.models.adol_tb_presence_household_member import \
@@ -27,13 +30,17 @@ from flourish_prn.action_items import CHILD_DEATH_REPORT_ACTION, \
 from flourish_prn.models import TBAdolOffStudy
 from flourish_prn.models.child_death_report import ChildDeathReport
 from pre_flourish.helper_classes import MatchHelper
+from . import InfantHIVTesting18Months, InfantHIVTesting9Months, \
+    InfantHIVTestingAfterBreastfeeding, \
+    InfantHIVTestingAge6To8Weeks, InfantHIVTestingBirth, InfantHIVTestingOther
 from .child_assent import ChildAssent
 from .child_clinician_notes import ClinicianNotesImage
 from .child_dummy_consent import ChildDummySubjectConsent
 from .child_visit import ChildVisit
 from ..action_items import YOUNG_ADULT_LOCATOR_ACTION
 from ..helper_classes import ChildFollowUpBookingHelper, ChildOnScheduleHelper
-from ..helper_classes.utils import (child_utils, notification, stamp_image,
+from ..helper_classes.utils import (child_utils, handle_notification, notification,
+                                    stamp_image,
                                     trigger_action_item)
 from ..models import AcademicPerformance, ChildOffSchedule, ChildSocioDemographic
 from ..models import ChildPreHospitalizationInline, InfantHIVTesting
@@ -391,16 +398,40 @@ def academic_performance_on_post_save(sender, instance, raw, created, **kwargs):
         if overall_performance and overall_performance == 'pending':
             child_visit = instance.child_visit
             subject = f'Pending academic results at visit {child_visit.visit_code}'
+            handle_notification(child_visit, instance, subject)
+
+
+def hiv_testing_and_resulting_on_post_save(sender, instance, raw, created, **kwargs):
+    if created:
+        no_results = [IND, PENDING, UNKNOWN]
+        if instance.hiv_test_result in no_results:
             try:
-                DataActionItem.objects.get(
-                    subject_identifier=child_visit.subject_identifier,
-                    subject=subject)
-            except DataActionItem.DoesNotExist:
-                notification(
-                    subject_identifier=child_visit.subject_identifier,
-                    user_created=instance.user_created,
-                    subject=subject,
-                    comment=f'{subject}. Please capture results once available.')
+                appointment_creator = UnscheduledAppointmentCreator(
+                    subject_identifier=instance.child_visit.subject_identifier,
+                    visit_schedule_name=instance.child_visit.appointment
+                    .visit_schedule_name,
+                    schedule_name=instance.child_visit.appointment.schedule_name,
+                    visit_code=instance.child_visit.appointment.visit_code,
+                    facility=instance.child_visit.appointment.facility,
+                    timepoint_datetime=instance.child_visit.appointment
+                    .timepoint_datetime,
+                    check_appointment=False
+                )
+                obj = appointment_creator.appointment
+                obj.save()
+            except UnscheduledAppointmentError as e:
+                child_visit = instance.child_visit
+                subject = f'Pending hiv results at visit {child_visit.visit_code}'
+                handle_notification(child_visit, instance, subject)
+
+
+hiv_testing_models = [InfantHIVTestingAfterBreastfeeding, InfantHIVTestingAge6To8Weeks,
+                      InfantHIVTesting9Months, InfantHIVTesting18Months,
+                      InfantHIVTestingBirth, InfantHIVTestingOther]
+
+for model_class in hiv_testing_models:
+    post_save.connect(hiv_testing_and_resulting_on_post_save, sender=model_class,
+                      weak=False, dispatch_uid='hiv_testing_and_resulting_on_post_save')
 
 
 @receiver(post_save, weak=False, sender=ChildPreHospitalizationInline,
@@ -561,7 +592,8 @@ def child_continued_consent_post_save(sender, instance, raw, created, **kwargs):
             onschedule_model_cls = django_apps.get_model(onschedule_model)
 
             '''Get only on schedule model so we can filter by caregiver_subject_identifier
-            and child_subject_identifier, that in turn will give us the correct schedule name a
+            and child_subject_identifier, that in turn will give us the correct 
+            schedule name a
             child is associated with'''
 
             schedule_objs = onschedule_model_cls.objects.filter(

--- a/flourish_child/mommy_recipes.py
+++ b/flourish_child/mommy_recipes.py
@@ -19,14 +19,14 @@ from flourish_child.models.child_phq_referral_fu import ChildPhqReferralFU
 from flourish_prn.models.tb_adol_off_study import TBAdolOffStudy
 from .models import (ChildAssent, ChildBirth, ChildClinicalMeasurements, ChildDataset,
                      ChildDummySubjectConsent, ChildFoodSecurityQuestionnaire, ChildVisit,
-                     HivTestingAdol,
-                     InfantDevScreening12Months, InfantDevScreening18Months,
-                     InfantDevScreening36Months,
+                     HivTestingAdol, InfantDevScreening12Months,
+                     InfantDevScreening18Months, InfantDevScreening36Months,
                      TbAdolAssent, TbAdolEngagement, TbAdolInterview, TbLabResultsAdol,
                      TbPresenceHouseholdMembersAdol, TbVisitScreeningAdolescent)
-from .models import ChildGadAnxietyScreening, ChildPhqDepressionScreening, \
-    ChildSocioDemographic, ChildTBReferral, InfantArvProphylaxis, InfantFeeding, \
-    InfantHIVTesting, ChildTBScreening, ChildContinuedConsent
+from .models import (ChildContinuedConsent, ChildGadAnxietyScreening,
+                     ChildPhqDepressionScreening, ChildSocioDemographic, ChildTBReferral,
+                     ChildTBScreening, InfantArvProphylaxis, InfantFeeding,
+                     InfantHIVTesting, InfantHIVTestingAfterBreastfeeding)
 
 fake = Faker()
 
@@ -278,6 +278,9 @@ childtbscreening = Recipe(
     ChildTBScreening,
 )
 
+infanthivtestingafterbreastfeeding = Recipe(
+    InfantHIVTestingAfterBreastfeeding,
+)
 
 childcontinuedconsent = Recipe(
     ChildContinuedConsent,

--- a/flourish_child/tests/test_hiv_infant_testing.py
+++ b/flourish_child/tests/test_hiv_infant_testing.py
@@ -1,5 +1,6 @@
 from dateutil.relativedelta import relativedelta
 from django.test import tag, TestCase
+from edc_appointment.constants import COMPLETE_APPT
 from edc_appointment.models import Appointment as CaregiverAppointment
 from edc_base import get_utcnow
 from edc_constants.constants import MALE, PENDING, POS, YES
@@ -259,6 +260,15 @@ class TestHivInfantTesting(TestCase):
     def test_infant_hiv_testing_results_pending(self):
         visit = self.create_2000_2001_visits()
         self.create_test_visit(visit=visit)
+
+        app = Appointment.objects.get(
+            visit_code='2001',
+            visit_code_sequence=0,
+            subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier)
+
+        app.appt_status = COMPLETE_APPT
+        app.save()
 
         mommy.make_recipe(
             'flourish_child.infanthivtestingafterbreastfeeding',


### PR DESCRIPTION
This commit includes updates in `apps.py`, `model_mixins.py`, `forms` files, and test files in the Flourish Child App. Changes are made to the `reason_field` in `EdcMetadataAppConfig` and reordering of import statements in `mommy_recipes.py`. In the `HIVTestingAndResultingMixin` class, a new condition has been added to the save function to accommodate unscheduled appointments. In several form classes in `infant_hiv_testing_form.py`, `SubjectModelFormMixin` was replaced by `ChildModelFormMixin`. Start of implementation of test scenarios for Infant HIV testing was also included. Signed-off-by: nmunatsibw 