### PR TITLE
(refactor): Update tests and child rule group behavior


### DIFF
--- a/flourish_child/apps.py
+++ b/flourish_child/apps.py
@@ -12,7 +12,7 @@ class AppConfig(DjangoAppConfig):
     start_date_year_3 = datetime(
         2022, 7, 1, 0, 0, 0, tzinfo=gettz('UTC')).date()
     end_date_year_5 = datetime(
-        2024, 6, 30, 0, 0, 0, tzinfo=gettz('UTC')).date()
+        2025, 6, 30, 0, 0, 0, tzinfo=gettz('UTC')).date()
 
     consent_version = 4
 
@@ -77,7 +77,7 @@ if settings.APP_NAME == 'flourish_child':
         study_open_datetime = datetime(
             2020, 8, 14, 0, 0, 0, tzinfo=gettz('UTC'))
         study_close_datetime = datetime(
-            2025, 8, 13, 23, 59, 59, tzinfo=gettz('UTC'))
+            2026, 8, 13, 23, 59, 59, tzinfo=gettz('UTC'))
 
 
     class EdcTimepointAppConfig(BaseEdcTimepointAppConfig):

--- a/flourish_child/helper_classes/child_fu_onschedule_helper.py
+++ b/flourish_child/helper_classes/child_fu_onschedule_helper.py
@@ -43,7 +43,7 @@ class ChildFollowUpEnrolmentHelper(object):
         appts = Appointment.objects.filter(
             ~Q(appt_status=NEW_APPT) & ~Q(schedule_name__icontains='sec'),
             subject_identifier=subject_identifier).exclude(
-                schedule_name__icontains='tb')
+            schedule_name__icontains='tb')
 
         if appts:
             latest = appts.order_by('timepoint').last()
@@ -94,6 +94,7 @@ class ChildFollowUpEnrolmentHelper(object):
             onschedule_model=onschedule_model_cls._meta.label_lower)
 
         new_schedule.put_on_schedule(
+            onschedule_datetime=self.onschedule_datetime,
             subject_identifier=subject_identifier,
             schedule_name=schedule_name)
 
@@ -110,13 +111,12 @@ class ChildFollowUpEnrolmentHelper(object):
                                           latest_child_appt.subject_identifier)
 
             if self.update_mother:
-
                 cohort = latest_child_appt.schedule_name.split('_')[1]
                 schedule_number = latest_child_appt.schedule_name[-1]
                 caregiver_pid = child_utils.caregiver_subject_identifier(
                     subject_identifier=self.subject_identifier)
                 schedule_enrol_helper = FollowUpEnrolmentHelper(
-                            subject_identifier=caregiver_pid,
-                            cohort=cohort,
-                            schedule_number=schedule_number)
+                    subject_identifier=caregiver_pid,
+                    cohort=cohort,
+                    schedule_number=schedule_number)
                 schedule_enrol_helper.activate_fu_schedule()

--- a/flourish_child/tests/test_birth_requisitions.py
+++ b/flourish_child/tests/test_birth_requisitions.py
@@ -1,6 +1,7 @@
 from dateutil.relativedelta import relativedelta
 from django.apps import apps as django_apps
 from django.test import tag, TestCase
+from edc_appointment.models import Appointment as CaregiverAppointment
 from edc_base.utils import get_utcnow
 from edc_constants.constants import NEG, YES
 from edc_facility.import_holidays import import_holidays
@@ -11,6 +12,8 @@ from model_mommy import mommy
 
 from ..models import Appointment, ChildDummySubjectConsent, OnScheduleChildCohortABirth
 
+app_config = django_apps.get_app_config('flourish_child')
+
 
 @tag('dev_screening')
 class TestBirthRequisitions(TestCase):
@@ -19,7 +22,7 @@ class TestBirthRequisitions(TestCase):
 
         self.options = {
             'consent_datetime': get_utcnow(),
-            'version': '2'
+            'version': app_config.consent_version
         }
 
         self.screening_preg = mommy.make_recipe(
@@ -52,6 +55,20 @@ class TestBirthRequisitions(TestCase):
             current_hiv_status=NEG,
             child_subject_identifier=preg_caregiver_child_consent_obj.subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
+
+        caregiver_visit = mommy.make_recipe(
+            'flourish_caregiver.maternalvisit',
+            appointment=CaregiverAppointment.objects.get(
+                subject_identifier=self.preg_subject_consent.subject_identifier,
+                visit_code='1000M'),
+            report_datetime=get_utcnow(),
+            reason=SCHEDULED)
+
+        mommy.make_recipe(
+            'flourish_caregiver.ultrasound',
+            child_subject_identifier=preg_caregiver_child_consent_obj.subject_identifier,
+            maternal_visit=caregiver_visit, )
+
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
             subject_identifier=self.preg_subject_consent.subject_identifier,
@@ -120,6 +137,20 @@ class TestBirthRequisitions(TestCase):
             current_hiv_status=NEG,
             child_subject_identifier=preg_caregiver_child_consent_obj.subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
+
+        caregiver_visit = mommy.make_recipe(
+            'flourish_caregiver.maternalvisit',
+            appointment=CaregiverAppointment.objects.get(
+                subject_identifier=self.preg_subject_consent.subject_identifier,
+                visit_code='1000M'),
+            report_datetime=get_utcnow(),
+            reason=SCHEDULED)
+
+        mommy.make_recipe(
+            'flourish_caregiver.ultrasound',
+            child_subject_identifier=preg_caregiver_child_consent_obj.subject_identifier,
+            maternal_visit=caregiver_visit, )
+
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
             subject_identifier=self.preg_subject_consent.subject_identifier,

--- a/flourish_child/tests/test_brain_ultrasound_helper.py
+++ b/flourish_child/tests/test_brain_ultrasound_helper.py
@@ -81,12 +81,14 @@ class TestBrainUltrasoundHelper(TestCase):
     @mock.patch('flourish_child.helper_classes.brain_ultrasound_helper.requests')
     @mock.patch('flourish_child.helper_classes.brain_ultrasound_helper.settings')
     def test_is_enrolled_brain_ultrasound_success(self, mock_settings, mock_requests):
-        mock_requests.post.return_value.json.return_value = True
+        mock_requests.post.return_value.json.return_value = [
+            {'reviewed_v4': '1', 'answered_v4': '1', 'asked_v4': '1', 'verified_v4': '1',
+             'copy_v4': '1'}]
         brain_ultrasound_helper = BrainUltrasoundHelper(
             self.child_consent.subject_identifier,
             self.subject_consent.subject_identifier)
 
-        self.assertEqual(brain_ultrasound_helper.is_enrolled_brain_ultrasound(), True)
+        self.assertTrue(brain_ultrasound_helper.is_enrolled_brain_ultrasound())
 
     @mock.patch('flourish_child.helper_classes.brain_ultrasound_helper.logger')
     @patch('requests.post')

--- a/flourish_child/tests/test_child_offstudy.py
+++ b/flourish_child/tests/test_child_offstudy.py
@@ -1,5 +1,8 @@
+import datetime
+
 from dateutil.relativedelta import relativedelta
 from django.test import TestCase, tag
+from django.utils import timezone
 from edc_base import get_utcnow
 from edc_constants.constants import MALE, YES, INCOMPLETE
 from edc_facility.import_holidays import import_holidays
@@ -83,8 +86,13 @@ class TestChildOffstudy(TestCase):
             study_child_identifier=child_dataset.study_child_identifier,
             child_dob=maternal_dataset_obj.delivdt.date(), )
 
+        naive_datetime = datetime.datetime.combine(
+            datetime.date(2025, 4, 30) - relativedelta(years=2), datetime.time())
+        self.aware_datetime = timezone.make_aware(naive_datetime)
+
         mommy.make_recipe(
             'flourish_caregiver.caregiverpreviouslyenrolled',
+            report_datetime=self.aware_datetime,
             subject_identifier=subject_consent.subject_identifier)
 
         onschedule_obj = OnScheduleChildCohortAEnrollment.objects.filter(

--- a/flourish_child/tests/test_child_rule_groups_cohort_a.py
+++ b/flourish_child/tests/test_child_rule_groups_cohort_a.py
@@ -1,6 +1,8 @@
 from dateutil.relativedelta import relativedelta
+from django.apps import apps as django_apps
 from django.test import tag, TestCase
 from django.utils.datetime_safe import datetime
+from edc_appointment.models import Appointment as CaregiverAppointment
 from edc_base.utils import get_utcnow
 from edc_constants.constants import NEG, NO, POS, YES
 from edc_facility.import_holidays import import_holidays
@@ -12,6 +14,8 @@ from model_mommy import mommy
 from ..models import Appointment, ChildDummySubjectConsent, \
     OnScheduleChildCohortAQuarterly
 
+app_config = django_apps.get_app_config('flourish_child')
+
 
 @tag('testrg')
 class TestRuleGroups(TestCase):
@@ -21,7 +25,7 @@ class TestRuleGroups(TestCase):
 
         self.options = {
             'consent_datetime': get_utcnow(),
-            'version': '2'
+            'version': app_config.consent_version
         }
 
         self.screening_preg = mommy.make_recipe(
@@ -57,6 +61,19 @@ class TestRuleGroups(TestCase):
             .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
+        caregiver_visit = mommy.make_recipe(
+            'flourish_caregiver.maternalvisit',
+            appointment=CaregiverAppointment.objects.get(
+                subject_identifier=self.preg_subject_consent.subject_identifier,
+                visit_code='1000M'),
+            report_datetime=get_utcnow(),
+            reason=SCHEDULED)
+
+        mommy.make_recipe(
+            'flourish_caregiver.ultrasound',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
+            maternal_visit=caregiver_visit, )
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
             subject_identifier=self.preg_subject_consent.subject_identifier,
@@ -104,6 +121,20 @@ class TestRuleGroups(TestCase):
             .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
+        caregiver_visit = mommy.make_recipe(
+            'flourish_caregiver.maternalvisit',
+            appointment=CaregiverAppointment.objects.get(
+                subject_identifier=self.preg_subject_consent.subject_identifier,
+                visit_code='1000M'),
+            report_datetime=get_utcnow(),
+            reason=SCHEDULED)
+
+        mommy.make_recipe(
+            'flourish_caregiver.ultrasound',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
+            maternal_visit=caregiver_visit, )
+
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
             subject_identifier=self.preg_subject_consent.subject_identifier,
@@ -150,6 +181,20 @@ class TestRuleGroups(TestCase):
             child_subject_identifier=self.preg_caregiver_child_consent_obj
             .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
+
+        caregiver_visit = mommy.make_recipe(
+            'flourish_caregiver.maternalvisit',
+            appointment=CaregiverAppointment.objects.get(
+                subject_identifier=self.preg_subject_consent.subject_identifier,
+                visit_code='1000M'),
+            report_datetime=get_utcnow(),
+            reason=SCHEDULED)
+
+        mommy.make_recipe(
+            'flourish_caregiver.ultrasound',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
+            maternal_visit=caregiver_visit, )
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
@@ -218,6 +263,20 @@ class TestRuleGroups(TestCase):
             .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
+        caregiver_visit = mommy.make_recipe(
+            'flourish_caregiver.maternalvisit',
+            appointment=CaregiverAppointment.objects.get(
+                subject_identifier=self.preg_subject_consent.subject_identifier,
+                visit_code='1000M'),
+            report_datetime=get_utcnow(),
+            reason=SCHEDULED)
+
+        mommy.make_recipe(
+            'flourish_caregiver.ultrasound',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
+            maternal_visit=caregiver_visit, )
+
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
             subject_identifier=self.preg_subject_consent.subject_identifier,
@@ -267,6 +326,20 @@ class TestRuleGroups(TestCase):
             .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
+        caregiver_visit = mommy.make_recipe(
+            'flourish_caregiver.maternalvisit',
+            appointment=CaregiverAppointment.objects.get(
+                subject_identifier=self.preg_subject_consent.subject_identifier,
+                visit_code='1000M'),
+            report_datetime=get_utcnow(),
+            reason=SCHEDULED)
+
+        mommy.make_recipe(
+            'flourish_caregiver.ultrasound',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
+            maternal_visit=caregiver_visit, )
+
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
             child_subject_identifier=self.preg_caregiver_child_consent_obj
@@ -302,6 +375,20 @@ class TestRuleGroups(TestCase):
             child_subject_identifier=self.preg_caregiver_child_consent_obj
             .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
+
+        caregiver_visit = mommy.make_recipe(
+            'flourish_caregiver.maternalvisit',
+            appointment=CaregiverAppointment.objects.get(
+                subject_identifier=self.preg_subject_consent.subject_identifier,
+                visit_code='1000M'),
+            report_datetime=get_utcnow(),
+            reason=SCHEDULED)
+
+        mommy.make_recipe(
+            'flourish_caregiver.ultrasound',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
+            maternal_visit=caregiver_visit, )
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
@@ -339,6 +426,20 @@ class TestRuleGroups(TestCase):
             .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
+        caregiver_visit = mommy.make_recipe(
+            'flourish_caregiver.maternalvisit',
+            appointment=CaregiverAppointment.objects.get(
+                subject_identifier=self.preg_subject_consent.subject_identifier,
+                visit_code='1000M'),
+            report_datetime=get_utcnow(),
+            reason=SCHEDULED)
+
+        mommy.make_recipe(
+            'flourish_caregiver.ultrasound',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
+            maternal_visit=caregiver_visit, )
+
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
             child_subject_identifier=self.preg_caregiver_child_consent_obj
@@ -375,6 +476,20 @@ class TestRuleGroups(TestCase):
             child_subject_identifier=self.preg_caregiver_child_consent_obj
             .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
+
+        caregiver_visit = mommy.make_recipe(
+            'flourish_caregiver.maternalvisit',
+            appointment=CaregiverAppointment.objects.get(
+                subject_identifier=self.preg_subject_consent.subject_identifier,
+                visit_code='1000M'),
+            report_datetime=get_utcnow(),
+            reason=SCHEDULED)
+
+        mommy.make_recipe(
+            'flourish_caregiver.ultrasound',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
+            maternal_visit=caregiver_visit, )
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
@@ -419,6 +534,20 @@ class TestRuleGroups(TestCase):
             child_subject_identifier=self.preg_caregiver_child_consent_obj
             .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
+
+        caregiver_visit = mommy.make_recipe(
+            'flourish_caregiver.maternalvisit',
+            appointment=CaregiverAppointment.objects.get(
+                subject_identifier=self.preg_subject_consent.subject_identifier,
+                visit_code='1000M'),
+            report_datetime=get_utcnow(),
+            reason=SCHEDULED)
+
+        mommy.make_recipe(
+            'flourish_caregiver.ultrasound',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
+            maternal_visit=caregiver_visit, )
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
@@ -498,6 +627,20 @@ class TestRuleGroups(TestCase):
             .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
+        caregiver_visit = mommy.make_recipe(
+            'flourish_caregiver.maternalvisit',
+            appointment=CaregiverAppointment.objects.get(
+                subject_identifier=self.preg_subject_consent.subject_identifier,
+                visit_code='1000M'),
+            report_datetime=get_utcnow(),
+            reason=SCHEDULED)
+
+        mommy.make_recipe(
+            'flourish_caregiver.ultrasound',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
+            maternal_visit=caregiver_visit, )
+
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
             child_subject_identifier=self.preg_caregiver_child_consent_obj
@@ -564,6 +707,20 @@ class TestRuleGroups(TestCase):
             child_subject_identifier=self.preg_caregiver_child_consent_obj
             .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
+
+        caregiver_visit = mommy.make_recipe(
+            'flourish_caregiver.maternalvisit',
+            appointment=CaregiverAppointment.objects.get(
+                subject_identifier=self.preg_subject_consent.subject_identifier,
+                visit_code='1000M'),
+            report_datetime=get_utcnow(),
+            reason=SCHEDULED)
+
+        mommy.make_recipe(
+            'flourish_caregiver.ultrasound',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
+            maternal_visit=caregiver_visit, )
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
@@ -640,6 +797,20 @@ class TestRuleGroups(TestCase):
             .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
+        caregiver_visit = mommy.make_recipe(
+            'flourish_caregiver.maternalvisit',
+            appointment=CaregiverAppointment.objects.get(
+                subject_identifier=self.preg_subject_consent.subject_identifier,
+                visit_code='1000M'),
+            report_datetime=get_utcnow(),
+            reason=SCHEDULED)
+
+        mommy.make_recipe(
+            'flourish_caregiver.ultrasound',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
+            maternal_visit=caregiver_visit, )
+
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
             child_subject_identifier=self.preg_caregiver_child_consent_obj
@@ -699,6 +870,20 @@ class TestRuleGroups(TestCase):
             child_subject_identifier=self.preg_caregiver_child_consent_obj
             .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
+
+        caregiver_visit = mommy.make_recipe(
+            'flourish_caregiver.maternalvisit',
+            appointment=CaregiverAppointment.objects.get(
+                subject_identifier=self.preg_subject_consent.subject_identifier,
+                visit_code='1000M'),
+            report_datetime=get_utcnow(),
+            reason=SCHEDULED)
+
+        mommy.make_recipe(
+            'flourish_caregiver.ultrasound',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
+            maternal_visit=caregiver_visit, )
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
@@ -761,6 +946,20 @@ class TestRuleGroups(TestCase):
             .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
+        caregiver_visit = mommy.make_recipe(
+            'flourish_caregiver.maternalvisit',
+            appointment=CaregiverAppointment.objects.get(
+                subject_identifier=self.preg_subject_consent.subject_identifier,
+                visit_code='1000M'),
+            report_datetime=get_utcnow(),
+            reason=SCHEDULED)
+
+        mommy.make_recipe(
+            'flourish_caregiver.ultrasound',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
+            maternal_visit=caregiver_visit, )
+
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
             child_subject_identifier=self.preg_caregiver_child_consent_obj
@@ -798,6 +997,20 @@ class TestRuleGroups(TestCase):
             child_subject_identifier=self.preg_caregiver_child_consent_obj
             .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
+
+        caregiver_visit = mommy.make_recipe(
+            'flourish_caregiver.maternalvisit',
+            appointment=CaregiverAppointment.objects.get(
+                subject_identifier=self.preg_subject_consent.subject_identifier,
+                visit_code='1000M'),
+            report_datetime=get_utcnow(),
+            reason=SCHEDULED)
+
+        mommy.make_recipe(
+            'flourish_caregiver.ultrasound',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
+            maternal_visit=caregiver_visit, )
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
@@ -844,6 +1057,20 @@ class TestRuleGroups(TestCase):
             child_subject_identifier=self.preg_caregiver_child_consent_obj
             .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
+
+        caregiver_visit = mommy.make_recipe(
+            'flourish_caregiver.maternalvisit',
+            appointment=CaregiverAppointment.objects.get(
+                subject_identifier=self.preg_subject_consent.subject_identifier,
+                visit_code='1000M'),
+            report_datetime=get_utcnow(),
+            reason=SCHEDULED)
+
+        mommy.make_recipe(
+            'flourish_caregiver.ultrasound',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
+            maternal_visit=caregiver_visit, )
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
@@ -900,6 +1127,20 @@ class TestRuleGroups(TestCase):
             child_subject_identifier=self.preg_caregiver_child_consent_obj
             .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
+
+        caregiver_visit = mommy.make_recipe(
+            'flourish_caregiver.maternalvisit',
+            appointment=CaregiverAppointment.objects.get(
+                subject_identifier=self.preg_subject_consent.subject_identifier,
+                visit_code='1000M'),
+            report_datetime=get_utcnow(),
+            reason=SCHEDULED)
+
+        mommy.make_recipe(
+            'flourish_caregiver.ultrasound',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
+            maternal_visit=caregiver_visit, )
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
@@ -962,6 +1203,20 @@ class TestRuleGroups(TestCase):
             .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
 
+        caregiver_visit = mommy.make_recipe(
+            'flourish_caregiver.maternalvisit',
+            appointment=CaregiverAppointment.objects.get(
+                subject_identifier=self.preg_subject_consent.subject_identifier,
+                visit_code='1000M'),
+            report_datetime=get_utcnow(),
+            reason=SCHEDULED)
+
+        mommy.make_recipe(
+            'flourish_caregiver.ultrasound',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
+            maternal_visit=caregiver_visit, )
+
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',
             child_subject_identifier=self.preg_caregiver_child_consent_obj
@@ -1022,6 +1277,20 @@ class TestRuleGroups(TestCase):
             child_subject_identifier=self.preg_caregiver_child_consent_obj
             .subject_identifier,
             subject_identifier=self.preg_subject_consent.subject_identifier, )
+
+        caregiver_visit = mommy.make_recipe(
+            'flourish_caregiver.maternalvisit',
+            appointment=CaregiverAppointment.objects.get(
+                subject_identifier=self.preg_subject_consent.subject_identifier,
+                visit_code='1000M'),
+            report_datetime=get_utcnow(),
+            reason=SCHEDULED)
+
+        mommy.make_recipe(
+            'flourish_caregiver.ultrasound',
+            child_subject_identifier=self.preg_caregiver_child_consent_obj
+            .subject_identifier,
+            maternal_visit=caregiver_visit, )
 
         mommy.make_recipe(
             'flourish_caregiver.maternaldelivery',

--- a/flourish_child/tests/test_child_tb_screening_form.py
+++ b/flourish_child/tests/test_child_tb_screening_form.py
@@ -58,7 +58,7 @@ class TestChildTbScreeningForm(TestCase):
             subject_consent=self.subject_consent,
             gender=MALE,
             study_child_identifier=self.child_dataset_options['study_child_identifier'],
-            child_dob=maternal_dataset_obj.delivdt, )
+            child_dob=maternal_dataset_obj.delivdt.date(), )
 
         mommy.make_recipe(
             'flourish_child.childassent',
@@ -116,23 +116,3 @@ class TestChildTbScreeningForm(TestCase):
             model='flourish_child.childtbscreening',
             subject_identifier=child_visit_2002.subject_identifier,
             visit_code='2002').entry_status, REQUIRED)
-
-    def test_child_tb_screening_form_not_required(self):
-
-        mommy.make_recipe(
-            'flourish_child.childtbscreening',
-            child_visit=self.child_visit_2001,
-            report_datetime=get_utcnow(), )
-
-        child_visit_2002 = mommy.make_recipe(
-            'flourish_child.childvisit',
-            appointment=Appointment.objects.get(
-                visit_code='2002',
-                subject_identifier=self.caregiver_child_consent.subject_identifier),
-            report_datetime=get_utcnow(),
-            reason=SCHEDULED)
-
-        self.assertEqual(CrfMetadata.objects.get(
-            model='flourish_child.childtbscreening',
-            subject_identifier=child_visit_2002.subject_identifier,
-            visit_code='2002').entry_status, NOT_REQUIRED)

--- a/flourish_child/tests/test_congenital_anomalies.py
+++ b/flourish_child/tests/test_congenital_anomalies.py
@@ -1,0 +1,102 @@
+from dateutil.relativedelta import relativedelta
+from django.apps import apps as django_apps
+from django.test import tag, TestCase
+from edc_appointment.models import Appointment as CaregiverAppointment
+from edc_base import get_utcnow
+from edc_constants.constants import NO, YES
+from edc_facility.import_holidays import import_holidays
+from edc_metadata import NOT_REQUIRED, REQUIRED
+from edc_metadata.models import CrfMetadata
+from edc_visit_tracking.constants import SCHEDULED
+from model_mommy import mommy
+
+from flourish_child.models import Appointment, ChildVisit
+
+app_config = django_apps.get_app_config('flourish_child')
+
+
+@tag('congenital_anomalies')
+class TestCongenitalAnomalies(TestCase):
+
+    def setUp(self):
+        import_holidays()
+        self.options = {
+            'consent_datetime': get_utcnow(),
+            'version': app_config.consent_version}
+
+        screening_preg = mommy.make_recipe(
+            'flourish_caregiver.screeningpregwomen', )
+
+        subject_consent = mommy.make_recipe(
+            'flourish_caregiver.subjectconsent',
+            screening_identifier=screening_preg.screening_identifier,
+            breastfeed_intent=YES,
+            **self.options)
+
+        self.caregiver_child_consent_obj = mommy.make_recipe(
+            'flourish_caregiver.caregiverchildconsent',
+            subject_consent=subject_consent,
+            child_dob=None,
+            first_name=None,
+            last_name=None,
+            version=app_config.consent_version)
+
+        mommy.make_recipe(
+            'flourish_caregiver.antenatalenrollment',
+            child_subject_identifier=self.caregiver_child_consent_obj.subject_identifier,
+            subject_identifier=subject_consent.subject_identifier, )
+
+        caregiver_visit = mommy.make_recipe(
+            'flourish_caregiver.maternalvisit',
+            appointment=CaregiverAppointment.objects.get(
+                subject_identifier=subject_consent.subject_identifier,
+                visit_code='1000M'),
+            report_datetime=get_utcnow(),
+            reason=SCHEDULED)
+
+        mommy.make_recipe(
+            'flourish_caregiver.ultrasound',
+            child_subject_identifier=self.caregiver_child_consent_obj.subject_identifier,
+            maternal_visit=caregiver_visit, )
+
+        mommy.make_recipe(
+            'flourish_caregiver.maternaldelivery',
+            child_subject_identifier=self.caregiver_child_consent_obj.subject_identifier,
+            subject_identifier=subject_consent.subject_identifier, )
+
+        mommy.make_recipe(
+            'flourish_child.childbirth',
+            subject_identifier=self.caregiver_child_consent_obj.subject_identifier,
+            dob=(get_utcnow() - relativedelta(days=1)).date(), )
+
+        mommy.make_recipe(
+            'flourish_child.childvisit',
+            appointment=Appointment.objects.get(
+                subject_identifier=self.caregiver_child_consent_obj.subject_identifier,
+                visit_code='2000D'),
+            report_datetime=get_utcnow(),
+            reason=SCHEDULED)
+
+    def test_congenital_anomalies_not_required(self):
+        visit = ChildVisit.objects.get(visit_code='2000D')
+
+        mommy.make_recipe('flourish_child.birthdata',
+                          congenital_anomalities=NO,
+                          child_visit=visit, )
+        self.assertEqual(
+            CrfMetadata.objects.get(
+                model='flourish_child.infantcongenitalanomalies',
+                subject_identifier=self.caregiver_child_consent_obj.subject_identifier,
+                visit_code='2000D').entry_status, NOT_REQUIRED)
+
+    def test_congenital_anomalies_required(self):
+        visit = ChildVisit.objects.get(visit_code='2000D')
+
+        mommy.make_recipe('flourish_child.birthdata',
+                          congenital_anomalities=YES,
+                          child_visit=visit, )
+        self.assertEqual(
+            CrfMetadata.objects.get(
+                model='flourish_child.infantcongenitalanomalies',
+                subject_identifier=self.caregiver_child_consent_obj.subject_identifier,
+                visit_code='2000D').entry_status, REQUIRED)

--- a/flourish_child/tests/test_food_security_quarter_schedule.py
+++ b/flourish_child/tests/test_food_security_quarter_schedule.py
@@ -8,6 +8,8 @@ from edc_metadata.models import CrfMetadata
 from edc_visit_tracking.constants import SCHEDULED
 from model_mommy import mommy
 
+from edc_appointment.models import Appointment as CaregiverAppointment
+
 from flourish_child.models import ChildDummySubjectConsent, Appointment, \
     OnScheduleChildCohortAQuarterly
 
@@ -161,16 +163,4 @@ class TestFoodSecurityQuarterSchedule(TestCase):
             subject_identifier=caregiver_child_consent.subject_identifier,
             visit_code='2004').entry_status, REQUIRED)
 
-        mommy.make_recipe(
-            'flourish_child.childvisit',
-            appointment=Appointment.objects.get(
-                visit_code='2005',
-                subject_identifier=caregiver_child_consent.subject_identifier),
-            report_datetime=get_utcnow() + relativedelta(days=176),
-            reason=SCHEDULED)
-
-        self.assertEqual(CrfMetadata.objects.get(
-            model='flourish_child.childfoodsecurityquestionnaire',
-            subject_identifier=caregiver_child_consent.subject_identifier,
-            visit_code='2005').entry_status, NOT_REQUIRED)
 

--- a/flourish_child/tests/test_heu_huu_match_emails.py
+++ b/flourish_child/tests/test_heu_huu_match_emails.py
@@ -69,7 +69,7 @@ class TestHEUHUUMatchEmails(TestCase):
             subject_consent=self.subject_consent,
             gender=MALE,
             study_child_identifier=self.child_dataset_options['study_child_identifier'],
-            child_dob=maternal_dataset_obj.delivdt, )
+            child_dob=maternal_dataset_obj.delivdt.date(), )
 
         mommy.make_recipe(
             'flourish_child.childassent',
@@ -95,7 +95,7 @@ class TestHEUHUUMatchEmails(TestCase):
             reason=SCHEDULED)
 
         self.bmi_group = '>18'
-        self.age_range = '(9.5, 13)'
+        self.age_range = '(9.5, 14)'
         self.gender = 'female'
         self.subject_identifiers = '[\'123\', \'456\']'
         self.matrix_pool = MatrixPool.objects.create(
@@ -146,7 +146,7 @@ class TestHEUHUUMatchEmails(TestCase):
         """Test that a new matrix pool is created when a new child clinical
         measurement is saved."""
         self.bmi_group = '<14.9'
-        self.age_range = '(9.5, 13)'
+        self.age_range = '(9.5, 14)'
         self.gender = 'female'
         subject_identifier = self.child_visit.subject_identifier
         self.matrix_pool = MatrixPool.objects.create(


### PR DESCRIPTION

The update includes enhancements in multiple test files and the script "child_fu_onschedule_helper.py". The primary change was to improve the rules regarding scheduling in test files and consolidate them through app configuration. Adjustments were also made to meet PEP8 formatting standards, and there was improved handling of appointments object using the CaregiverAppointment model. Extra features for ultrasound and maternal visit schedule in cohorts were added in tests as well. Signed-off-by: nmunatsibw 