### PR TITLE
(refactor): Update verbose name in child_socio_demographic model



### DIFF
--- a/flourish_child/models/child_socio_demographic.py
+++ b/flourish_child/models/child_socio_demographic.py
@@ -72,5 +72,5 @@ class ChildSocioDemographic(ChildSocioDemographicMixin, ChildCrfModelMixin):
 
     class Meta(ChildCrfModelMixin.Meta):
         app_label = 'flourish_child'
-        verbose_name = "Child Sociodemographic Data"
-        verbose_name_plural = "Child Sociodemographic Data"
+        verbose_name = "Child Sociodemographic Data Version 2"
+        verbose_name_plural = "Child Sociodemographic Data Version 2"


### PR DESCRIPTION
This commit updates the verbose name and verbose_name_plural fields in the child_socio_demographic model from "Child Sociodemographic Data" to "Child Sociodemographic Data Version 2". This change is necessary to differentiate them from previous versions. Signed-off-by: nmunatsibw 