### PR TITLE
(refactor): Remove null and blank attributes from HIV test result field


### DIFF
--- a/flourish_child/models/model_mixins/hiv_testing_and_resulting_mixin.py
+++ b/flourish_child/models/model_mixins/hiv_testing_and_resulting_mixin.py
@@ -57,8 +57,7 @@ class HIVTestingAndResultingMixin(models.Model):
         verbose_name='What is the result of the HIV test?',
         choices=POS_NEG_PENDING_UNKNOWN,
         max_length=20,
-        null=True,
-        blank=True
+        default=''
     )
 
     additional_comments = models.TextField(


### PR DESCRIPTION

This commit removes the `null` and `blank` attributes from the HIV test result field in the `hiv_testing_and_resulting_mixin.py` file, and replaces them with a `default` attribute. This ensures that every instance of this field in the database has a default value, eliminating potential issues with handling null or blank entries. Signed-off-by: nmunatsibw 