### PR TITLE
(refactor): Improve method for prefilling menarche dates in ChildPregTestingForm



### DIFF
--- a/flourish_child/forms/child_preg_testing_form.py
+++ b/flourish_child/forms/child_preg_testing_form.py
@@ -22,9 +22,17 @@ class ChildPregTestingForm(ChildModelFormMixin, forms.ModelForm):
         kwargs['initial'] = initial
         super().__init__(*args, **kwargs)
 
-        for key in self.menarche_fields:
-            if initial.get(key, None):
-                self.fields[key].widget = forms.DateInput(attrs={'readonly': 'readonly'})
+        if initial.get('menarche_start_dt', None):
+            self.fields['menarche_start_dt'].widget = forms.DateInput(
+                attrs={'readonly': 'readonly'})
+
+        if initial.get('menarche_start_est', None):
+            self.fields['menarche_start_est'].widget = forms.CharField(
+                attrs={'readonly': 'readonly'})
+
+        if initial.get('menarche', None):
+            self.fields['menarche'].widget = forms.CharField(
+                attrs={'readonly': 'readonly'})
 
     @property
     def menarche_fields(self):


### PR DESCRIPTION
This commit refines the method for prefilling menarche dates in the ChildPregTestingForm. The refactoring replaces the previous mechanism of filling in the initial object before instantiation. The update includes a more efficient extraction of relevant fields and attributes from previous instances, as well as optimized rules for setting readonly attributes on forms. Signed-off-by: nmunatsibw 