### PR TITLE
(refactor): Update widget types in child_preg_testing_form


### DIFF
--- a/flourish_child/forms/child_preg_testing_form.py
+++ b/flourish_child/forms/child_preg_testing_form.py
@@ -25,13 +25,11 @@ class ChildPregTestingForm(ChildModelFormMixin, forms.ModelForm):
         if initial.get('menarche_start_dt', None):
             self.fields['menarche_start_dt'].widget = forms.DateInput(
                 attrs={'readonly': 'readonly'})
-
         if initial.get('menarche_start_est', None):
-            self.fields['menarche_start_est'].widget = forms.CharField(
+            self.fields['menarche_start_est'].widget = forms.TextInput(
                 attrs={'readonly': 'readonly'})
-
         if initial.get('menarche', None):
-            self.fields['menarche'].widget = forms.CharField(
+            self.fields['menarche'].widget = forms.TextInput(
                 attrs={'readonly': 'readonly'})
 
     @property


### PR DESCRIPTION

This commit replaces the CharField widget types with TextInput in 'menarche_start_est' and 'menarche' fields in the child_preg_testing_form. This aims to increase input flexibility while preserving the readonly attribute of these form fields. Signed-off-by: nmunatsibw 