### PR TITLE
(refactor): Improve condition check in child_preg_testing_form



### DIFF
--- a/flourish_child/forms/child_preg_testing_form.py
+++ b/flourish_child/forms/child_preg_testing_form.py
@@ -25,7 +25,8 @@ class ChildPregTestingForm(ChildModelFormMixin, forms.ModelForm):
         if initial.get('menarche_start_dt', None):
             self.fields['menarche_start_dt'].widget = forms.DateInput(
                 attrs={'readonly': 'readonly'})
-        if initial.get('menarche_start_est', None):
+        if (initial.get('menarche_start_est', None) and
+                initial.get('menarche_start_est', None) != NOT_APPLICABLE):
             self.fields['menarche_start_est'].widget = forms.TextInput(
                 attrs={'readonly': 'readonly'})
         if initial.get('menarche', None):


### PR DESCRIPTION
The code in the child_preg_testing_form has been refactored to improve readability and functionality. The condition check for 'menarche_start_est' not only checks for the presence of the key but also ensures its value is not 'NOT_APPLICABLE'. This change enhances the robustness of the initial form checks. Signed-off-by: nmunatsibw 