### PR TITLE
(refactor): Modify child_preg_testing_form initialization



### DIFF
--- a/flourish_child/forms/child_preg_testing_form.py
+++ b/flourish_child/forms/child_preg_testing_form.py
@@ -16,8 +16,10 @@ class ChildPregTestingForm(ChildModelFormMixin, forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         initial = kwargs.pop('initial', {})
+        instance = kwargs.get('instance', None)
         previous_instance = getattr(self, 'previous_instance', None)
-        initial = self.prefill_menarche_dates(initial, previous_instance)
+        if not instance:
+            initial = self.prefill_menarche_dates(initial, previous_instance)
 
         kwargs['initial'] = initial
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
This change modifies the __init__ method in child_preg_testing_form.py. The update involves checking for an instance in the kwargs. If there's no instance, the method prefill_menarche_dates is being called. This could help prevent unnecessary prefilling menarche dates when an instance already exists. Signed-off-by: nmunatsibw 