### PR TITLE
(child_tb_screening_model): Remove allowance for null and blank fields


### DIFF
--- a/flourish_child/models/child_tb_screening.py
+++ b/flourish_child/models/child_tb_screening.py
@@ -79,8 +79,7 @@ class ChildTBScreening(TBScreeningMixin, ChildCrfModelMixin):
         verbose_name='Since the last time you spoke with FLOURISH staff, has your child '
                      'been evaluated in a clinic for TB? ',
         choices=YES_NO_UKN_CHOICES,
-        blank=True,
-        null=True,
+        default='',
         max_length=20,
     )
 


### PR DESCRIPTION

Removed the null and blank fields allowance for child TB screening in the 'flourish_child' model. Now, by default, it will be an empty string instead of accepting blank or null values. This aims to maintain the data integrity of the TB screening details in the database. Signed-off-by: nmunatsibw 