### PR TITLE
(update): Import NONE constant and apply in child_tb_screening_form_validator


### DIFF
--- a/flourish_child/choices.py
+++ b/flourish_child/choices.py
@@ -1471,7 +1471,7 @@ HOUSE_YEAR_BUILT_CHOICES = (
     ("1991-2000", '1991-2000'),
     ("2001-2010", '2001-2010'),
     ("2011-2019", '2011-2019'),
-    ("2019_above", '2019 and After'),
+    ("2019_after", '2019 and After'),
     (DONT_KNOW, 'I don’t know'),
 )
 

--- a/flourish_child/choices.py
+++ b/flourish_child/choices.py
@@ -1471,7 +1471,7 @@ HOUSE_YEAR_BUILT_CHOICES = (
     ("1991-2000", '1991-2000'),
     ("2001-2010", '2001-2010'),
     ("2011-2019", '2011-2019'),
-    ("2019_above", '2019 and above'),
+    ("2019_above", '2019 and After'),
     (DONT_KNOW, 'I don’t know'),
 )
 

--- a/flourish_child/choices.py
+++ b/flourish_child/choices.py
@@ -1447,16 +1447,6 @@ CARETAKERS = [
     (OTHER, 'Other'),
 ]
 
-BUILT_DATES = (
-    ('before_1980', 'Before 1980'),
-    ('1980-1990', '1980-1990'),
-    ('1991-2000', '1991-2000'),
-    ('2001-2010', '2001-2010'),
-    ('2011-2019', '2011-2019'),
-    ('after_2019', 'After 2019'),
-    ('i_dont_know', 'I don’t know'),
-)
-
 CAREGIVER_EDUCATION_LEVEL_CHOICES = (
     ('no_prim_male_caregiver', 'No primary male caregiver'),
     ('not_educated', 'Not educated'),

--- a/flourish_child/choices.py
+++ b/flourish_child/choices.py
@@ -1447,22 +1447,22 @@ CARETAKERS = [
     (OTHER, 'Other'),
 ]
 
+BUILT_DATES = (
+    ('before_1980', 'Before 1980'),
+    ('1980-1990', '1980-1990'),
+    ('1991-2000', '1991-2000'),
+    ('2001-2010', '2001-2010'),
+    ('2011-2019', '2011-2019'),
+    ('after_2019', 'After 2019'),
+    ('i_dont_know', 'I don’t know'),
+)
+
 CAREGIVER_EDUCATION_LEVEL_CHOICES = (
     ('no_prim_male_caregiver', 'No primary male caregiver'),
     ('not_educated', 'Not educated'),
     ('primary', 'Primary'),
     ('secondary', 'Secondary'),
     ('tertiary', 'Tertiary')
-)
-
-HOUSE_YEAR_BUILT_CHOICES = (
-    ('before_1980', 'Before 1980'),
-    ('1980-1990', '1980-1990'),
-    ("1991-2000", '1991-2000'),
-    ("2001-2010", '2001-2010'),
-    ("2011-2019", '2011-2019'),
-    ("2019_after", '2019 and After'),
-    (DONT_KNOW, 'I don’t know'),
 )
 
 BUSINESSES_RUN = (

--- a/flourish_child/models/child_socio_demographic.py
+++ b/flourish_child/models/child_socio_demographic.py
@@ -4,7 +4,7 @@ from edc_constants.choices import YES_NO
 
 from .child_crf_model_mixin import ChildCrfModelMixin
 from .model_mixins.child_socio_demographic_mixin import ChildSocioDemographicMixin
-from ..choices import CARETAKERS, HOUSE_YEAR_BUILT_CHOICES, YES_NO_DONT_KNOW
+from ..choices import CARETAKERS, BUILT_DATES, YES_NO_DONT_KNOW
 
 
 class ChildSocioDemographic(ChildSocioDemographicMixin, ChildCrfModelMixin):
@@ -51,7 +51,7 @@ class ChildSocioDemographic(ChildSocioDemographicMixin, ChildCrfModelMixin):
     building_date = models.CharField(
         verbose_name='When was the house you live in now built?',
         max_length=25,
-        choices=HOUSE_YEAR_BUILT_CHOICES,
+        choices=BUILT_DATES,
         default=''
     )
 

--- a/flourish_child/models/child_socio_demographic.py
+++ b/flourish_child/models/child_socio_demographic.py
@@ -4,7 +4,7 @@ from edc_constants.choices import YES_NO
 
 from .child_crf_model_mixin import ChildCrfModelMixin
 from .model_mixins.child_socio_demographic_mixin import ChildSocioDemographicMixin
-from ..choices import BUILT_DATES, CARETAKERS, YES_NO_DONT_KNOW
+from ..choices import CARETAKERS, HOUSE_YEAR_BUILT_CHOICES, YES_NO_DONT_KNOW
 
 
 class ChildSocioDemographic(ChildSocioDemographicMixin, ChildCrfModelMixin):
@@ -51,7 +51,7 @@ class ChildSocioDemographic(ChildSocioDemographicMixin, ChildCrfModelMixin):
     building_date = models.CharField(
         verbose_name='When was the house you live in now built?',
         max_length=25,
-        choices=BUILT_DATES,
+        choices=HOUSE_YEAR_BUILT_CHOICES,
         default=''
     )
 


### PR DESCRIPTION

An update has been made to the child_tb_screening_form_validator.py. The 'NONE' constant from the edc_constants module was imported and used to replace the string 'none'. Signed-off-by: nmunatsibw 