### PR TITLE
(update): Import NONE constant and apply in child_tb_screening_form_validator


### DIFF
--- a/flourish_child/choices.py
+++ b/flourish_child/choices.py
@@ -1454,4 +1454,33 @@ BUILT_DATES = (
     ('2001-2010', '2001-2010'),
     ('2011-2019', '2011-2019'),
     ('after_2019', 'After 2019'),
-    ('i_dont_know', 'I don’t know'))
+    ('i_dont_know', 'I don’t know'),
+)
+
+CAREGIVER_EDUCATION_LEVEL_CHOICES = (
+    ('no_prim_male_caregiver', 'No primary male caregiver'),
+    ('not_educated', 'Not educated'),
+    ('primary', 'Primary'),
+    ('secondary', 'Secondary'),
+    ('tertiary', 'Tertiary')
+)
+
+HOUSE_YEAR_BUILT_CHOICES = (
+    ('before_1980', 'Before 1980'),
+    ('1980-1990', '1980-1990'),
+    ("1991-2000", '1991-2000'),
+    ("2001-2010", '2001-2010'),
+    ("2011-2019", '2011-2019'),
+    ("2019_above", '2019 and above'),
+    (DONT_KNOW, 'I don’t know'),
+)
+
+BUSINESSES_RUN = (
+    ('seamstress', 'Seamstress'),
+    ('welding', 'Welding'),
+    ('vehicle_repair', 'Vehicle repair'),
+    ('furniture_construction', 'Furniture construction/repair'),
+    ('selling', 'Selling'),
+    ('painting', 'Painting'),
+    (OTHER, 'Other'),
+)


### PR DESCRIPTION

An update has been made to the child_tb_screening_form_validator.py. The 'NONE' constant from the edc_constants module was imported and used to replace the string 'none'. Signed-off-by: nmunatsibw 